### PR TITLE
AddFaceDirection undefined behavior fix 

### DIFF
--- a/src/Defines.cpp
+++ b/src/Defines.cpp
@@ -404,7 +404,7 @@ Vector3i AddFaceDirection(const Vector3i a_Position, const eBlockFace a_BlockFac
 		case BLOCK_FACE_NONE: break;
 	}
 
-	UNREACHABLE("Unsupported block face");
+	return a_Position;
 }
 
 


### PR DESCRIPTION
This change is in response to this issue, https://github.com/cuberite/cuberite/issues/5441. In the event that AddFaceDirection is called with an invalid eBlockFace the function will simply return the position is was called with, rather than crashing the server. Another solution to this is outlined by madmaxoft in a comment on the original issue, but this is beyond my abilities to implement at the moment, so consider this a temporary solution if that would work better for the purposes of the project.